### PR TITLE
corrigido docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       context: ./frontend
     command: npm run dev -- --host #host option for vite
     volumes:
-      - frontend_build:/frontend/build
+      - frontend_build:/frontend/dist #normalmente é build, mas o vite coloca dentro de dist por padrão
     ports:
       - "5173:5173"
   nginx:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,11 +5,6 @@ RUN npm install
 
 COPY . . 
 
-RUN mkdir -p /frontend/build
-
 RUN npm run build
 
-
-RUN chmod -R 755 /frontend/build
-
-CMD ["npm", "run", "dev", "--", "--host"]
+CMD ["npm", "run", "build", "dev", "--", "--host"]


### PR DESCRIPTION
o vite coloca a builld do frontend por padrão dentro da pasta dist, estava tentando colocar dentro de build por engano